### PR TITLE
Details pop up

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ const modalImage = modal.querySelector('.modal-body img');
 const modalDescription = modal.querySelector('.grid-lorem');
 const modalSkills = modal.querySelector('.languagessss');
 const modalLiveButton = modal.querySelector('.button-container button:nth-child(1)');
-const modalSourceButton = modal.querySelector(".button-container button:nth-child(2)");
+const modalSourceButton = modal.querySelector('.button-container button:nth-child(2)');
 document.querySelectorAll('.btn').forEach((card) => {
   card.onclick = () => {
     const id = card.getAttribute('title');
@@ -134,10 +134,10 @@ document.querySelectorAll('.btn').forEach((card) => {
       modalSkills.append(li);
     }
   };
-  modalLiveButton.addEventListener("click", () => {
-      window.open(projects.liveLink);
+  modalLiveButton.addEventListener('click', () => {
+    window.open(projects.liveLink);
   });
-  modalSourceButton.addEventListener("click",() => {
-      window.open(projects.sourceLink);
+  modalSourceButton.addEventListener('click', () => {
+    window.open(projects.sourceLink);
   });
 });

--- a/index.js
+++ b/index.js
@@ -65,8 +65,8 @@ const projects = [
     year: '2015',
     lorem: 'Experimental content creation feature that allows users to add to an existing story over the course of a day without spamming their friends.',
     language: ['HTML', 'CSS', 'JavaScript'],
-    liveLink: 'https://example.com/project2',
-    sourceLink: 'https://github.com/project2',
+    liveLink: 'https://ordinarymack.github.io/Portfolio-Contact-form/',
+    sourceLink: 'https://github.com/OrdinaryMack/Portfolio-Contact-form',
   },
   {
     imagePath: './image/679f12c86bb033399c6b604b71698f3c.png',
@@ -76,8 +76,8 @@ const projects = [
     year: '2015',
     lorem: 'Experimental content creation feature that allows users to add to an existing story over the course of a day without spamming their friends.',
     language: ['HTML', 'CSS', 'JavaScript'],
-    liveLink: 'https://example.com/project2',
-    sourceLink: 'https://github.com/project2',
+    liveLink: 'https://ordinarymack.github.io/Portfolio-Contact-form/',
+    sourceLink: 'https://github.com/OrdinaryMack/Portfolio-Contact-form',
   },
   {
 
@@ -88,8 +88,8 @@ const projects = [
     year: '2015',
     lorem: 'Experimental content creation feature that allows users to add to an existing story over the course of a day without spamming their friends.',
     language: ['HTML', 'CSS', 'JavaScript'],
-    liveLink: 'https://example.com/project2',
-    sourceLink: 'https://github.com/project2',
+    liveLink: 'https://ordinarymack.github.io/Portfolio-Contact-form/',
+    sourceLink: 'https://github.com/OrdinaryMack/Portfolio-Contact-form',
   },
   {
 
@@ -100,8 +100,8 @@ const projects = [
     year: '2015',
     lorem: 'Experimental content creation feature that allows users to add to an existing story over the course of a day without spamming their friends.',
     language: ['HTML', 'CSS', 'JavaScript'],
-    liveLink: 'https://example.com/project2',
-    sourceLink: 'https://github.com/project2',
+    liveLink: 'https://ordinarymack.github.io/Portfolio-Contact-form/',
+    sourceLink: 'https://github.com/OrdinaryMack/Portfolio-Contact-form',
   },
 ];
 
@@ -127,6 +127,12 @@ document.querySelectorAll('.btn').forEach((card) => {
     modalImage.src = projects[id].imagePath;
     modalDescription.textContent = projects[id].lorem;
     modalSkills.textContent = '';
+    modalLiveButton.addEventListener('click', () => {
+      window.open(projects[id].liveLink);
+    });
+    modalSourceButton.addEventListener('click', () => {
+      window.open(projects[id].sourceLink);
+    });
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < projects[id].language.length; i++) {
       const li = document.createElement('li');
@@ -134,10 +140,4 @@ document.querySelectorAll('.btn').forEach((card) => {
       modalSkills.append(li);
     }
   };
-  modalLiveButton.addEventListener('click', () => {
-    window.open(projects.liveLink);
-  });
-  modalSourceButton.addEventListener('click', () => {
-    window.open(projects.sourceLink);
-  });
 });

--- a/style.css
+++ b/style.css
@@ -34,7 +34,7 @@ header {
   height: 50px;
   display: flex;
   justify-content: space-between;
-  z-index: 100;
+  z-index: 1;
 }
 
 .logo a {
@@ -910,6 +910,7 @@ button:hover {
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.5);
   pointer-events: none;
+  z-index: 1;
 }
 
 #overlay.active {


### PR DESCRIPTION
In this pull request
I implemented the following interactions:

When the user clicks (or taps) the button to check project details, the popup with details about the project appears.
When the user clicks (or taps) the close (X) button, the popup disappears.
In order to associate each project with the popup window details, you must refactor the project section:
I used a JavaScript array to store all of the information for all projects.
For each project you need to store the following pieces of data in a JavaScript object, at a minimum: name, description, featured image, technologies, link to live version, link to source.
I updated the main page so that the projects section is created dynamically using the information stored in that JavaScript object.  All of the HTML in that section is created when the page loads.
After that, I implemented the popup window.
-No linters errors