### PR TITLE
Add Local storage to the file

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,3 +171,34 @@ form.addEventListener('submit', (e) => {
     errorElement.innerHTML = messages.join(', ');
   }
 });
+// Function to save form data to local storage
+function saveFormData() {
+  const formData = {
+    name: document.getElementById('name').value,
+    email: document.getElementById('email').value,
+    letters: document.querySelector('.report').value,
+  };
+
+  // Convert the data to a JSON string and save it to local storage
+  localStorage.setItem('formData', JSON.stringify(formData));
+}
+function loadFormData() {
+  const storedData = localStorage.getItem('formData');
+
+  if (storedData) {
+    const formData = JSON.parse(storedData);
+    document.getElementById('name').value = formData.name;
+    document.getElementById('email').value = formData.email;
+    document.querySelector('.report').value = formData.letters;
+  }
+}
+
+const inputFields = document.querySelectorAll('input');
+const textarea = document.querySelector('.report');
+
+inputFields.forEach((input) => {
+  input.addEventListener('input', saveFormData);
+});
+
+textarea.addEventListener('input', saveFormData);
+loadFormData();

--- a/style.css
+++ b/style.css
@@ -656,15 +656,17 @@ form input {
   border-radius: 8px;
   margin-left: 34px;
   border: none;
+  outline: none;
 }
 
 .report {
-  height: 180px;
   margin-left: 34px;
   width: 80%;
   margin-top: 10px;
   font-family: Arial, Helvetica, sans-serif;
   border-radius: 8px;
+  padding: 10px;
+  outline: none;
 }
 
 form .error-message {


### PR DESCRIPTION
In this pull Request -
I implemented the following interactions:
When the user changes the content of any input field, the data is saved to the local storage.
When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.
I used the following data model:
You must create a single JavaScript object with all the data from the entire form and save it in local storage. Do not create one local storage entry per input field.